### PR TITLE
0.0.3 Using Documentation

### DIFF
--- a/using.md
+++ b/using.md
@@ -59,7 +59,7 @@ pb secrets registry apply -f path/to/<example-registry-creds>.yaml
 
 **Current Constraints** 
 
-* Users can only pass one registry secret per command
+* Users can only add a secret at a time
 * The registry credential that a given team uses can be updated by modifying the above file and running the `pb secrets registry apply` command. 
 
 2) Associating a git credential with a team.  If a user wants Build Service to execute builds against app source code that lives in a private git repository, they must associate a git secret with the team they previously created.

--- a/using.md
+++ b/using.md
@@ -265,7 +265,7 @@ This should follow along with the progress of the build and terminate when the b
 **Current Constraints:**
 
 * Pivotal Build Service only stores the ten most recent successful builds and ten most recent failed builds.
-* Users cannot retrive logs by refrencing the image digest, the must use the build number
+* Users cannot retrieve logs by referencing the image digest, they must use the build number
 
 ### <a id='delete'></a> Deleting `teams` and `images`
 

--- a/using.md
+++ b/using.md
@@ -28,7 +28,7 @@ This command prompts you for a `username` and `password` which correspond to you
 `BUILD_SERVICE_USERNAME` and `BUILD_SERVICE_PASSWORD`. The CLI will default to pick these up and use them if they exist in the environment.
 
 
-### <a id='create-team'></a> Creating a `team` and managing memebers
+### <a id='create-team'></a> Creating a `team` and managing members
 
 A `team` is an entity in Pivotal Build Service that is used to manage authentication for the images built by Pivotal Build Service and to manage registry and git credentials for the images managed by said team.  Only the users that belong to a team will be allowed to create images against said team. Additionally, they will be the only ones who can check the builds against an image.
 

--- a/using.md
+++ b/using.md
@@ -28,69 +28,57 @@ This command prompts you for a `username` and `password` which correspond to you
 `BUILD_SERVICE_USERNAME` and `BUILD_SERVICE_PASSWORD`. The CLI will default to pick these up and use them if they exist in the environment.
 
 
-### <a id='create-team'></a> Creating a `team`
+### <a id='create-team'></a> Creating a `team` and managing memebers
 
 A `team` is an entity in Pivotal Build Service that is used to manage authentication for the images built by Pivotal Build Service and to manage registry and git credentials for the images managed by said team.  Only the users that belong to a team will be allowed to create images against said team. Additionally, they will be the only ones who can check the builds against an image.
 
-```
-pb team create example-team-name
-```
+First, a user can create a team and give it a name by running `pb team create <team-name>`.  By creating a team, that user is added to the team.  Team members can add other users to a team by referencing their UAA username by running `pb team user add <uaa-user@company.com> <example-team-name>`.  Users can remove team members by running `pb team user remove <uaa-user@company.com> <example-team-name>`. 
 
 **Current Constraints:**
+
+* Team structure is flat, all members of a team are also team “owners” and are allowed to create new images, manage secrets, and add/remove other users from the team
 * Cannot reference UAA user groups
+* The email address must exist in UAA
+* Each team must have at least one team member, if a particular team is no longer useful, users can delete a team by running `pb team delete <team-name>`
+    * Additional details for deletion workflows are captured in a below section
 
-#### <a id='add-secrets'></a> Add secrets to team
+Next, to effectively utilize the team they created, users must associate image registry credentials and git credentials (if the source code lives in a private git repo) with the team. 
 
-1. A file in which a registry credential is associated with a team.  Build Service will utilize this credentials to deliver container image builds to the user's specified registry.  The registry credential provided should belong to a user with `write` access on the registry.
+1) Associating a registry credential with a team.  Build Service will utilize these credentials to deliver container image builds to the user's specified registry.  The registry credential provided should belong to a user with `write` access on the registry. 
 
-    ```yaml
-    team: example-team-name
-    registry: registry.default.com
-    username: <registry username>
-    password: <registry password>
-    ```
-    And then run
-    ```
-    pb secrets registry apply -f path/to/<example-registry-creds>.yaml
-    ```
-
-    **Current Constraints**
-
-    * Users can only pass one registry secret per command
-    * The registry credential a given team uses can be updated by modifying the above file and running the 
-    `pb secrets registry apply` command.
-
-1. A file in which a git secrets is declared.  If a user wants Build Service to execute builds against app source code that lives in a private git repository, they must associate a git secret with the team they previously created (see step 1).
-
-    ```yaml
-    team: example-team-name
-    repository: github.com
-    username: testuser
-    password: ********
-    ```
-    And then run
-    ```
-    pb secrets git apply -f path/to/<example-git-secret>.yaml
-    ```
-
-    **Note**  The git secret a given team uses can be updated by modifying the above file and running the 
-    `pb secrets git apply` command.
-
-    As you apply each of these files, the `pb` CLI will provide feedback indicating whether or not the commands succeeded.
-
-
-#### <a id='add-ownwers'></a> Add Owners to team
-
-Add additional team owners, by running the command
-
+```yaml
+team: example-team-name
+registry: registry.default.com
+username: <registry username>
+password: <registry password>
 ```
-pb team user add some-user@email.com --team example-team-name
+And then run 
+```
+pb secrets registry apply -f path/to/<example-registry-creds>.yaml
 ```
 
-The owners will be allowed to create new images, manage secrets and users in the team
+**Current Constraints** 
 
-**Current Constrainst**
-* The email address need to exist in UAA
+* Users can only pass one registry secret per command
+* The registry credential a given team uses can be updated by modifying the above file and running the `pb secrets registry apply` command. 
+
+2) Associating a git credential with a team.  If a user wants Build Service to execute builds against app source code that lives in a private git repository, they must associate a git secret with the team they previously created.
+
+```yaml
+team: example-team-name
+repository: github.com
+username: testuser
+password: ********
+```
+And then run 
+```
+pb secrets git apply -f path/to/<example-git-secret>.yaml
+```
+
+**Note**  The git secret a given team uses can be updated by modifying the above file and running the `pb secrets git apply` command. 
+
+As you apply the registry and git secret files, the `pb` CLI will provide feedback indicating whether or not the commands succeeded.
+
 
 ### <a id='create-image'></a> Creating an `image`
 
@@ -100,20 +88,20 @@ An image defines the specification that Pivotal Build Service uses to create ima
 team: example-team-name
 source:
   git:
-    url: https://github.com/example-org/sample-node-app
+    url: https://github.com/example-org/sample-java-app
     revision: master
 build:
   env:
   - name: BP_JAVA_VERSION
     value: 8.*
 image:
-  tag: registry.default.com/my-team-folder/node-app-image
+  tag: registry.default.com/my-team-folder/java-app-image
 ```
 
 It is composed of the following components:
 
 1. The `team` that the image belongs to. It has to be the team you are a part of as well. You can only create images for teams you belong to.
-1. The `source` defines the git location of the code that images will be built against. The `revision` can either be a branch, tag or a commit-sha. When targeted against a branch, a build is triggered for every new commit. In case this is a private git repo, its credentials must be specified in the `repositories` section of the team configuration.
+1. The `source` defines the git location of the code that images will be built against. The `revision` can either be a branch, tag or a commit-sha. When targeted against a branch, a build is triggered for every new commit. 
 1. The `build` defines additional configuration you would like your app to be built with.  The `env` is a list of environment variables that will be provided to the build. Each environment variable is an object with `name` and `value`.
 1. An `image registry` defines the destination registry of the builds for the image. The credentials for the target registry must be specified in the `registries` section of the team configuration. This should also match the domain of one of the registries provided in the team configuration.
 
@@ -121,20 +109,44 @@ The value of `image.tag` will be used to refer to the image once it has been cre
 
 The above image configuration can be saved as `<my-example-image>.yaml`
 
-The configuration of the image can be applied to Pivotal Build Service:
+**Creating an `image` against source code in a git repo**
+
+The above configuration of the image can be applied to Pivotal Build Service:
 
 ```bash
 pb image apply -f /path/to/<my-example-image>.yaml
 ```
 
-Pivotal Build Service auto-rebuilds images when one or more of the following things change:
+**Creating an image using local source code**
+
+Build Service supports builds against source code that lives in a git repository or locally on a users machine.  However, users can only specify one source code location.  To replicate the above image creation workflow using local source code, users can modify the file by removing the git fields.  The resulting file would look like this:
+
+```yaml
+team: example-team-name
+source:
+build:
+  env:
+  - name: BP_JAVA_VERSION
+    value: 8.*
+image:
+  tag: registry.default.com/my-team-folder/sample-java-app
+```
+
+Users would apply this image configuration and specify a path to their application.
+
+```bash
+pb image apply -f /path/to/<my-example-image>.yaml -p /path/to/app_directory
+```
+
+### <a id='create-image'></a> Rebuilds
+
+Pivotal Build Service auto-rebuilds images when one or more of the following build inputs change:
 1. New buildpack versions are made available through an updated builder image
 1. New commit on a branch or tag Pivotal Build Service is tracking
-1. Updating the commit, branch, or git repo on the image's configuration file and re-applying it via `pb image apply`
+1. Updating the commit, branch, git repo, or build fields on the image's configuration file and re-applying it via `pb image apply`
 
 **Current Constraints:**
 
-* Users can only specify source code that lives in a git repository
 * Pivotal Build Service does not rebuild images based on new OS packages (like cflinuxfs3)
 
 ### <a id='monitor-builds'></a> Monitoring `builds` for an `image`
@@ -148,21 +160,31 @@ pb image builds <image-tag>
 The `<image-tag>` in the above command is the value of the field `image.tag` in the image's configuration. The output of the command might look similar to what's described below:
 
 ```
-Build    Status     Image       Started Time           Finished Time
------    ------     -----       ------------           -------------
-    1    SUCCESS    f5a1725f    2019-07-08 21:55:27    2019-07-08 21:56:54
-    2    SUCCESS    428fe93e    2019-07-08 21:56:55    2019-07-08 21:57:40
-    3    FAILED       --        2019-07-08 21:58:55    2019-07-08 21:59:40
-    4    BUILDING     --        2019-07-08 21:58:55          --
-    -    PENDING      --              --                     --
+Build    Status    Started Time           Finished Time          Reason    Digest  
+-----    ------    ------------           -------------          ------    ------
+    1    SUCCESS   2019-09-09 21:55:27    2019-07-08 21:56:54    CONFIG    *************************************************             
+    2    SUCCESS   2019-09-09 21:56:55    2019-07-08 21:57:40    COMMIT    *************************************************
+    3    FAILED    2019-09-09 21:58:55    2019-07-08 21:59:40    CONFIG+   --
+    4    BUILDING  2019-09-09 21:58:55    --                     BUILDER   --
+    -    PENDING   --                     --                     UNKNOWN   --
 ```
 
 1. The `Build` column describes the index of builds in the order that they were built.
-1. The `Status` column describes the status of a previous or a running/pending build.
-1. The `Image` column contains the SHA256 of the image successfully built.
+1. The `Status` column describes the status of a previous or a running/pending build image.
 1. The  `Started Time` and `Finished Time` columns described when a build was kicked off and when it was completed.
+1. The `Reason` column provides the user with information as to why an image rebuild occured. These reasons include
+* `CONFIG`
+    * Occurs when a change is made to commit, branch, git repo, or build fields on the image's configuration file and the user ran `pb image apply`
+* `COMMIT`
+    * Occurs when new source code is committed to a branch or tag build service is monitoring for changes
+* `BUILDER`
+    * Occurs when new buildpack versions are made available through an updated builder image
 
-To get the logs of a particular build, run the following:
+**Note:** It is possible for a rebuild to occur for more than one `Reason`.  In this instance, a `+` sign is appended to the `Reason` and the primary `Reason` is displayed.  Priority for the `Reason` is ranked `CONFIG`, `COMMIT`, `BUILDER`, in descending order       
+ 
+ 5. The `Digest` column contains the SHA256 of the image successfully built.  Users can reference this SHA to perform helpful Docker commands like `pull` and `inspect`
+
+**Retrieving logs of a particular build**
 
 ```bash
 pb image logs <image-tag> -b <build-number>
@@ -243,10 +265,11 @@ This should follow along with the progress of the build and terminate when the b
 **Current Constraints:**
 
 * Pivotal Build Service only stores the ten most recent successful builds and ten most recent failed builds.
+* Users cannot retrive logs by refrencing the image digest, the must use the build number
 
 ### <a id='delete'></a> Deleting `teams` and `images`
 
-#### <a id='delete-image'></a> Delete `image`
+**Delete `image`**
 
 The commands to delete a team and an image are similar to each other. To delete an image run:
 
@@ -283,17 +306,3 @@ and
 ```
 pb secrets git delete github.com -t example-team-name
 ```
-
-#### <a id='remove-owner'></a> Remove owner from team
-
-Execute the following command
-
-```
-pb team user remove some-user@email.com --team example-team-name
-```
-
-Users can remove themselfs from a team.
-
-The teams need to have at least 1 owners associated with tehm.
-
-The user needs to be an owners of a team in order to remove other members.

--- a/using.md
+++ b/using.md
@@ -40,7 +40,7 @@ The team owners can add other users to a team by referencing their UAA username 
 
 * Team structure is flat, all members of a team are also team “owners” and are allowed to create new images, manage secrets, and add/remove other users from the team
 * Cannot reference UAA user groups
-* The email address must exist in UAA
+* When adding a user the provided email address must exist in UAA
 * Each team must have at least one team member, if a particular team is no longer useful, users can delete a team by running `pb team delete <team-name>`
     * Additional details for deletion workflows are captured in a below section
 

--- a/using.md
+++ b/using.md
@@ -144,6 +144,7 @@ Pivotal Build Service auto-rebuilds images when one or more of the following bui
 1. New buildpack versions are made available through an updated builder image
 1. New commit on a branch or tag Pivotal Build Service is tracking
 1. Updating the commit, branch, git repo, or build fields on the image's configuration file and re-applying it via `pb image apply`
+1. Uploading a new copy of local source via `pb image apply -p`
 
 **Current Constraints:**
 

--- a/using.md
+++ b/using.md
@@ -60,7 +60,7 @@ pb secrets registry apply -f path/to/<example-registry-creds>.yaml
 **Current Constraints** 
 
 * Users can only pass one registry secret per command
-* The registry credential a given team uses can be updated by modifying the above file and running the `pb secrets registry apply` command. 
+* The registry credential that a given team uses can be updated by modifying the above file and running the `pb secrets registry apply` command. 
 
 2) Associating a git credential with a team.  If a user wants Build Service to execute builds against app source code that lives in a private git repository, they must associate a git secret with the team they previously created.
 

--- a/using.md
+++ b/using.md
@@ -46,7 +46,7 @@ The team owners can add other users to a team by referencing their UAA username 
 
 Next, to effectively utilize the team they created, users must associate image registry credentials and git credentials (if the source code lives in a private git repo) with the team. 
 
-1) Associating a registry credential with a team.  Build Service will utilize these credentials to deliver container image builds to the user's specified registry.  The registry credential provided should belong to a user with `write` access on the registry. 
+1) Associating a registry credential with a team.  Build Service will utilize these credentials to deliver container image builds to the user's specified registry.  The registry credential provided should belong to a user with `write` access on the registry. Currently, build service has tested and recommends using Docker Hub, GCR, Harbor, or Artifactory.  Since Docker Hub and GCR are hosted services, when referencing these registries in the `registry` field, use the domain names `index.docker.io` and `gcr.io` respectively.  For Artifactory or Harbor, reference the domain that is specific to your deployment of the registry. 
 
 ```yaml
 team: example-team-name

--- a/using.md
+++ b/using.md
@@ -123,7 +123,6 @@ Build Service supports builds against source code that lives in a git repository
 
 ```yaml
 team: example-team-name
-source:
 build:
   env:
   - name: BP_JAVA_VERSION

--- a/using.md
+++ b/using.md
@@ -32,7 +32,9 @@ This command prompts you for a `username` and `password` which correspond to you
 
 A `team` is an entity in Pivotal Build Service that is used to manage authentication for the images built by Pivotal Build Service and to manage registry and git credentials for the images managed by said team.  Only the users that belong to a team will be allowed to create images against said team. Additionally, they will be the only ones who can check the builds against an image.
 
-First, a user can create a team and give it a name by running `pb team create <team-name>`.  By creating a team, that user is added to the team.  Team members can add other users to a team by referencing their UAA username by running `pb team user add <uaa-user@company.com> <example-team-name>`.  Users can remove team members by running `pb team user remove <uaa-user@company.com> <example-team-name>`. 
+First, a user can create a team and give it a name by running `pb team create <team-name>`.  By creating a team, that user is added to the team.  
+
+The team owners can add other users to a team by referencing their UAA username by running `pb team user add <uaa-user@company.com> <example-team-name>`. Users can remove team members by running `pb team user remove <uaa-user@company.com> <example-team-name>`. 
 
 **Current Constraints:**
 


### PR DESCRIPTION
Addressed:

* Declaring teams using pb
* Adding/removing team members
* `pb image apply` referencing local source code
* The changes we made to the `pb image builds table`

Should we cover the default memory resources build service utilizes?  Or does that not belong here