### PR TITLE
Add link to order definition documentation

### DIFF
--- a/managing-builders.html.md.erb
+++ b/managing-builders.html.md.erb
@@ -15,7 +15,7 @@ To create a builder with the `pb` cli, you must create a builder configuration Y
 
 * `scope`: Defines whether the builder is available to the all users in the cluster or to users of the currently targeted project. One of 'Cluster' or 'Project'.
 
-* `order`: The buildpack order that the builder will use.
+* `order`: The buildpack order that the builder will use. For more information on listing buildpacks in groups, access <a href="https://buildpacks.io/docs/reference/builder-config/#order-_list-required_">documentation in buildpacks.io</a> 
 
 <p class='note'><strong>Note:</strong> Build Service must have the appropriate credentials to push to <code>tag</code>. Build Service has access to the registry used at install time and any secrets attached to the current project.</p>
 


### PR DESCRIPTION
In response to comments from PAs that this isn't clear when creating builders. 