### PR TITLE
Update installing docs for 0.2.0

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -19,8 +19,6 @@ Before you install Build Service, you must:
 
 * Download the Build Service Bundle from the [Tanzu Build Service](https://network.pivotal.io/products/build-service/) page on Tanzu Network.
 
-* Download the Build Service Dependencies from the [Tanzu Build Service Dependencies](https://network.pivotal.io/products/tbs-dependencies/) page on Tanzu Network.
-
 ## <a id='other-install'></a> Installing on TKG/GKE/AKS
 
 Create a kubernetes cluster that you would like to install build service onto and target the cluster as follow:
@@ -57,9 +55,10 @@ To create a credentials file:
     Where:
     * `PATH-TO-KUBECONFIG` is the path to the kubeconfig configuration file on your local machine.
        This file is required to enable Build Service to interact with the target cluster.
-    * `PATH-TO-CA` is the path to the CA. This CA is required to enable Build Service
+    * `PATH-TO-CA` is the path to the registry root CA. This CA is required to enable Build Service
        to interact with internally deployed registries.
        This is the CA that was used while deploying the registry.
+       If the registry you are using is not internally deployed (eg. gcr, dockerhub), this can be set to `""`.
     <p class="note"><strong>Note:</strong> All local paths in the credentials file must be absolute.</p>
 
 ### <a id='other-relocate-images'></a> Relocate Images to a Registry
@@ -67,7 +66,9 @@ To create a credentials file:
 This procedure relocates images from the Build Service bundle that you downloaded from Tanzu Network
 to an internal image registry.
 
-To move the images from the Build Service bundle to an internal image registry:
+<p class="note"><strong>Note:</strong> Keep in mind an image <strong>repository</strong> (eg. gcr.io/repository) is a location inside an image <strong>registry</strong> (eg. gcr.io) </p>
+
+To move the images from the Build Service bundle to an image registry:
 
 1. Log in to the image registry where you want to store the images by running:
 
@@ -76,13 +77,13 @@ To move the images from the Build Service bundle to an internal image registry:
     ```
     Where `IMAGE-REGISTRY` is the name of the image registry where you want to store the images.
 
-1. Push the images to the image registry by running:
+1. Push the images to the image repository by running:
 
     ```
-    duffle relocate -f /tmp/build-service-${version}.tgz -m /tmp/relocated.json -p IMAGE-REGISTRY
+    duffle relocate -f /tmp/build-service-${version}.tgz -m /tmp/relocated.json -p IMAGE-REPOSITORY
     ```
 
-    <p class="note"><strong>Note:</strong> When relocating to a harbor/gcr registry, the IMAGE-REGISTRY will need to be appended with the destination folder for the images eg. IMAGE-REGISTRY/build-service-imgs</p>
+    <p class="note"><strong>Note:</strong> When relocating to a harbor/gcr repository, the IMAGE-REGISTRY will need to be appended with the destination folder for the images eg. IMAGE-REGISTRY/build-service-imgs</p>
 
     For example:
     * Dockerhub `duffle relocate -f /tmp/build-service-0.1.0.tgz -m /tmp/relocated.json -p my-dockerhub-repo`
@@ -112,8 +113,8 @@ Where:
     <p class="note"><strong>Note:</strong> For Docker Hub, the domain must be <code>index.docker.io</code>.
   Do not include subpaths in the registry. <code>gcr.io</code> and <code>acr.io</code> are
   examples of valid fields for the registry.</p>
-* `DOCKER-REPOSITORY` is the image registry where stack images and store buildpackages will be relocated.
-    <p class="note"><strong>Note:</strong> This is identical to the IMAGE_REGISTRY argument provided during duffle relocation.</p>
+* `DOCKER-REPOSITORY` is the image repository where stack images and store buildpackages will be relocated.
+    <p class="note"><strong>Note:</strong> This is identical to the IMAGE-REPOSITORY argument provided during duffle relocation.</p>
 * `REGISTRY-USERNAME` is the username you use to access the registry. `gcr.io` expects `_json_key`
    as the username when using JSON key file authentication.
 * `REGISTRY-PASSWORD` is the password you use to access the registry.
@@ -194,9 +195,10 @@ To create a credentials file:
     Where:
     * `PATH-TO-KUBECONFIG` is the path to the kubeconfig configuration file on your local machine.
        This file is required to enable Build Service to interact with the target cluster.
-    * `PATH-TO-CA` is the path to the CA. This CA is required to enable Build Service
+    * `PATH-TO-CA` is the path to the registry root CA. This CA is required to enable Build Service
        to interact with internally deployed registries.
        This is the CA that was used while deploying the registry.
+       If the registry you are using is not internally deployed (eg. gcr, dockerhub), this can be set to `""`.
     <p class="note"><strong>Note:</strong> All local paths in the credentials file must be absolute.</p>
 
 ### <a id='relocate-images'></a> Relocate Images to a Registry
@@ -204,7 +206,9 @@ To create a credentials file:
 This procedure relocates images from the Build Service bundle that you downloaded from Tanzu Network
 to an internal image registry.
 
-To move the images from the Build Service bundle to an internal image registry:
+<p class="note"><strong>Note:</strong> Keep in mind an image <strong>repository</strong> (eg. gcr.io/repository) is a location inside an image <strong>registry</strong> (eg. gcr.io) </p>
+
+To move the images from the Build Service bundle to an image registry:
 
 1. Log in to the image registry where you want to store the images by running:
 
@@ -213,13 +217,13 @@ To move the images from the Build Service bundle to an internal image registry:
     ```
     Where `IMAGE-REGISTRY` is the name of the image registry where you want to store the images.
 
-1. Push the images to the image registry by running:
+1. Push the images to the image repository by running:
 
     ```
-    duffle relocate -f /tmp/build-service-${version}.tgz -m /tmp/relocated.json -p IMAGE-REGISTRY
+    duffle relocate -f /tmp/build-service-${version}.tgz -m /tmp/relocated.json -p IMAGE-REPOSITORY
     ```
 
-    <p class="note"><strong>Note:</strong> When relocating to a harbor/gcr registry, the IMAGE-REGISTRY will need to be appended with the destination folder for the images eg. IMAGE-REGISTRY/build-service-imgs</p>
+    <p class="note"><strong>Note:</strong> When relocating to a harbor/gcr repository, the IMAGE-REGISTRY will need to be appended with the destination folder for the images eg. IMAGE-REGISTRY/build-service-imgs</p>
 
     For example:
     * Dockerhub `duffle relocate -f /tmp/build-service-0.1.0.tgz -m /tmp/relocated.json -p my-dockerhub-repo`
@@ -230,7 +234,6 @@ To move the images from the Build Service bundle to an internal image registry:
 ### <a id='standard-install'></a> Run Duffle  Install
 
 Use Duffle to install Build Service and define the required Build Service parameters by running:
-
 
     duffle install BUILD-SERVICE-INSTALLATION-NAME -c /tmp/credentials.yml  \
         --set kubernetes_env=CLUSTER-NAME \
@@ -250,8 +253,8 @@ Where:
     <p class="note"><strong>Note:</strong> For Docker Hub, the domain must be <code>index.docker.io</code>.
   Do not include subpaths in the registry. <code>gcr.io</code> and <code>acr.io</code> are
   examples of valid fields for the registry.</p>
-* `DOCKER-REPOSITORY` is the image registry where stack images and store buildpackages will be relocated.
-    <p class="note"><strong>Note:</strong> This is identical to the IMAGE_REGISTRY argument provided during duffle relocation.</p>
+* `DOCKER-REPOSITORY` is the image repository where stack images and store buildpackages will be relocated.
+    <p class="note"><strong>Note:</strong> This is identical to the IMAGE-REPOSITORY argument provided during duffle relocation.</p>
 * `REGISTRY-USERNAME` is the username you use to access the registry. `gcr.io` expects `_json_key`
    as the username when using JSON key file authentication.
 * `REGISTRY-PASSWORD` is the password you use to access the registry.
@@ -277,17 +280,19 @@ Verify your Build Service installation by first targeting the cluster Build Serv
 
 To verify your Build Service installation:
 
-1. Download the `pb` binary from the [Tanzu Build Service](https://network.pivotal.io/products/build-service/) page on Tanzu Network.
+1. Download the `kp` binary from the [Tanzu Build Service](https://network.pivotal.io/products/build-service/) page on Tanzu Network.
 
-1. List the builders available in your installation:
+1. List the custom cluster builders available in your installation:
 
-    pb builder list
+    kp custom-cluster-builder list
 
 You should see an output that looks as follows:
 
-    Cluster Builders
-    ----------------
-    default
+    NAME       READY    STACK                                 IMAGE
+    base       true     io.buildpacks.stacks.bionic           <image@sha256:digest>
+    default    true     io.paketo.stacks.full    			  <image@sha256:digest>
+    full       true     io.paketo.stacks.full    			  <image@sha256:digest>
+    tiny       true     io.paketo.stacks.tiny          	 	  <image@sha256:digest>
 
 
 ## <a id='update-deps'></a> Updating Build Service Dependencies
@@ -297,59 +302,62 @@ Visit the [Build Service dependencies tile on PivNet](https://network.pivotal.io
 
 ### <a id='update-online-deps'></a> Online update of Dependencies
 
-If the `pb` CLI has access to pull images from the Pivnet Registry, the stack images and buildpacks used by build service can be updated using the following commands.
+If the `kp` CLI has access to pull images from the Pivnet Registry, the stack images and buildpacks used by build service can be updated using the following commands.
 
 #### Stack Update
 
-Update the stack:
+Update the stacks:
 
-    pb stack update --build-image registry.pivotal.io/tbs-dependencies/build@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run@sha256:<image-sha>
+    kp stack update default --build-image registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha>
+    kp stack update full --build-image registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha>
+    kp stack update tiny --build-image registry.pivotal.io/tbs-dependencies/build-tiny@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-tiny@sha256:<image-sha>
+    kp stack update base --build-image registry.pivotal.io/tbs-dependencies/build-base@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-base@sha256:<image-sha>
 
-<p class="note"><strong>Note:</strong> Both build and run images need to be provided to update the stack</p>
+<p class="note"><strong>Note:</strong> Both build and run images need to be provided to update a stack</p>
 
-The updated stack can be viewed with the following command:
+An updated stack can be viewed with the following command:
 
-    pb stack status
+    kp stack status <stack-name>
 
 #### Store Update
 
-Update the store:
+Update a store:
 
-    pb store add registry.pivotal.io/tbs-dependencies/<buildpack-name>:<buildpack-tag>
+    kp store add <store-name> registry.pivotal.io/tbs-dependencies/<buildpack-name>:<buildpack-tag>
 
 Additionally, multiple buildpacks can be added to Build Service by passing multiple image references
 
-    pb store add registry.pivotal.io/tbs-dependencies/<buildpack1>:<buildpack1-tag> registry.pivotal.io/tbs-dependencies/<buildpack2>:<buildpack2-tag> registry.pivotal.io/tbs-dependencies/<buildpack3>:<buildpack3-tag>
+    kp store add <store-name> registry.pivotal.io/tbs-dependencies/<buildpack1>:<buildpack1-tag> registry.pivotal.io/tbs-dependencies/<buildpack2>:<buildpack2-tag> registry.pivotal.io/tbs-dependencies/<buildpack3>:<buildpack3-tag>
 
-To list the buildpacks now available to build service:
+To list the buildpacks now available in the store:
 
-    pb store list
+    kp store status <store-name>
 
 ### <a id='update-offline-deps'></a> Offline update of Dependencies
 
-If the `pb` CLI cannot access the images in the Pivnet Registry, the stack images and buildpacks used by build service can be updated by first downloading those images and saving them as `.tar` files. These file can be provided to the `pb` CLI to upload to build service.
+If the `kp` CLI cannot access the images in the Pivnet Registry, the stack images and buildpacks used by build service can be updated by first downloading those images and saving them as `.tar` files. These file can be provided to the `kp` CLI to upload to build service.
 
 #### Stack Update
 
 Fetch the stack images into the docker daemon:
 
-    docker pull registry.pivotal.io/tbs-dependencies/build@sha256:<image-sha>
-    docker pull registry.pivotal.io/tbs-dependencies/run@sha256:<image-sha>
+    docker pull registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha>
+    docker pull registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha>
 
 Save those images to disk:
 
-    docker save registry.pivotal.io/tbs-dependencies/build@sha256:<image-sha> > build.tar
-    docker save registry.pivotal.io/tbs-dependencies/run@sha256:<image-sha> > run.tar
+    docker save registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha> > build.tar
+    docker save registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha> > run.tar
 
 Update the stack with the saved image:
 
-    pb stack update --build-image build.tar --run-image run.tar --local
+    kp stack update default --build-image build.tar --run-image run.tar --local
 
 <p class="note"><strong>Note:</strong> Both build and run images need to be provided to update the stack</p>
 
 The updated stack can be viewed with the following command:
 
-    pb stack status
+    kp stack status default
 
 #### Store Update
 
@@ -366,15 +374,15 @@ Save those images to disk:
 
 Update the store with the previously saved images:
 
-    pb store add buildpack1.tar --local
+    kp store add <store-name> buildpack1.tar --local
 
 Additionally, multiple buildpacks can be added to Build Service by passing multiple image references
 
-    pb store add buildpack1.tar buildpack2.tar --local
+    kp store add buildpack1.tar buildpack2.tar --local
 
-To list the buildpacks now available to build service:
+To list the buildpacks now available in the store:
 
-    pb store list
+    kp store status <store-name>
 
 
 ## <a id='ensure-readable-run-image'></a> Ensuring the Run Image is Readable
@@ -383,11 +391,11 @@ Build Service relies on the run-image being publicly readable or readable with t
 
 The location of the run image can be identified by running the following command:
 
-    pb stack status
+    kp stack status <stack-name>
 
 To update the the location of the run image:
 
 1. Using `kubectl` update the `buildservice.pivotal.io/defaultRepository` annotation on the `build-service-stack` Stack resource to a location that can be accessed publicly.
-1. Re-run [`pb stack update`](managing-stack.html) with the most recent build image and run image from the [build-service-dependencies](updating-deps.html) page.
+1. Re-run [`kp stack update`](managing-stack.html) with the most recent build image and run image from the [build-service-dependencies](updating-deps.html) page.
 
 


### PR DESCRIPTION
- Changes pb usage to kp

- Remove prerequisite to download TBS dependencies because you don't actually have to download them unless you are doing an offline relocation which we have specific steps for. 
  - Otherwise you might get stuck on that prerequisite.

- The example for updating stacks I expanded to all stacks to show that you need to use different pivnet repository images for each stack (eg. run-full for full stack). 
  - Otherwise you might try running that command and get the wrong stack id from run/build images.

- Specified the duffle `credentials.ca_cert` is the root CA for the registry and that it can be set to `""` for non-self-signed certs. 
  - I got stuck on this step when I first tried. Also `PATH-TO-CA is the path to the CA` doesn't mean much to me.

- Called out explicitly when to use a registry and when to use a repository during installation. 
  - This may be convoluted for some readers but is technically correct. 
  - If we don't want to make this change for simplicity, that makes sense
  - The only thing that I think should definitely change is the step that says:
```
DOCKER-REPOSITORY is the image registry where stack images and store buildpackages will be relocated.
Note: This is identical to the IMAGE_REGISTRY argument provided during duffle relocation.
```