### PR TITLE
Docs suggestions

### DIFF
--- a/managing-secrets.html.md.erb
+++ b/managing-secrets.html.md.erb
@@ -4,12 +4,12 @@ owner: Build Service Team
 ---
 
 # <a id='managing-secrets'></a> Managing Secrets
-[kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) are utilized to manage secrets within Tanzu Build Service.
+[kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/) are utilized to manage credentials within Tanzu Build Service.
 
 - Registry secret is required to publish images to a registry
 - Git secret is required to utilize source code stored in a private git repository
 
-Secrets are namespaced and so, available to image configurations only within the same namespace. Note that a `project` maps to a `namespace`.
+Secrets are namespaced and therefore only available to image configurations within the same namespace
 
 Secret management is made easier by using the `kp` cli.
 ```shell
@@ -41,8 +41,8 @@ We will go through the workflow of creating:
 
 **Note:** `kp` does not validate the secret against the specified registry or git at the time of secret creation. Incorrect creds will be reported at the time of its usage, during an image build.
 
-### <a id='docker-registry-secret'></a> Docker registry secret
-You can create a secret to a docker registry by running the command below. Users will be prompted to enter the password.
+### <a id='registry-secret'></a> Registry secret
+You can create a secret to any registry by running the command below. Users will be prompted to enter the password.
 ```shell
 $ kp secret create my-harbor-creds \
   --registry registry.pivotal.io \
@@ -52,10 +52,10 @@ registry password:
 ```
 Alternatively, use the `REGISTRY_PASSWORD` environment variable to bypass the password prompt.
 
-The docker registry secret is stored as a `kubernetes.io/dockerconfigjson` secret.
+The registry secret is stored as a `kubernetes.io/dockerconfigjson` secret.
 
-### <a id='docker-hub-registry-secret'></a> Docker Hub registry secret
-Creating a Docker Hub registry secret is easy with `kp`:
+### <a id='docker-hub-registry-secret'></a> DockerHub registry secret
+Creating a DockerHub registry secret is easy with `kp`:
 ```shell
 $ kp secret create my-dockerhub-creds \
   --dockerhub dockerhub-id
@@ -64,7 +64,7 @@ dockerhub password:
 ```
 Alternatively, use the `DOCKER_PASSWORD` environment variable to bypass the password prompt.
 
-The docker hub registry secret is stored as a `kubernetes.io/dockerconfigjson` secret.
+The dockerhub registry secret is stored as a `kubernetes.io/dockerconfigjson` secret.
 
 ### <a id='gcr-registry-secret'></a> GCR registry secret
 Creating a GCR registry secret is easy with `kp`:


### PR DESCRIPTION
- secret -> credentials to not repeat "secret" twice
- remove reference to "projects" as I don't think we need it if we don't reference projects elsewhere
- Remove references to docker in the "registry secret" section incase it gets confused with a dockerhub registry secret
- docker hub -> dockerhub