### PR TITLE
Update to point to Paketo for dependency upgrades

### DIFF
--- a/updating-deps.html.md.erb
+++ b/updating-deps.html.md.erb
@@ -7,33 +7,50 @@ Visit the [The Paketo Buildpacks Github repo](https://github.com/paketo-buildpac
 
 ## <a id='online-update'></a> Online update of Dependencies
 
-The Paketo repository contains references to images for buildpacks that are divided by language family (java, node, etc...) and stack images. Use the `kp` CLI to update these dependencies by referring to the desired images using the below commands. 
+The Paketo repository contains references to images called "buildpackages" that are divided by language family (java, node, etc...) and stacks. Use the `kp` CLI to update these dependencies by referring to the desired images using the below commands. 
+
+<p class="note"><strong>Note:</strong> The NodeJS and Java buildpackages are not currently available for store updates. TBS is installed with the NodeJS and Java buildpacks and updates will be supplied in the future.</p>
 
 ### <a id='online-stack-update'></a> Stacks Update
 
 Update the stacks:
-
+```
     kp stack update base --build-image gcr.io/paketo-buildpacks/build:base-cnb --run-image gcr.io/paketo-buildpacks/run:base-cnb
     kp stack update default --build-image gcr.io/paketo-buildpacks/build:full-cnb-cf --run-image index.docker.io/paketobuildpacks/build:full-cnb-cf
-    kp stack update default --build-image gcr.io/paketo-buildpacks/build:full-cnb-cf --run-image index.docker.io/paketobuildpacks/build:full-cnb-cf
+    kp stack update full --build-image gcr.io/paketo-buildpacks/build:full-cnb-cf --run-image index.docker.io/paketobuildpacks/build:full-cnb-cf
     kp stack update tiny --build-image gcr.io/paketo-buildpacks/build:tiny-cnb --run-image gcr.io/paketo-buildpacks/run:tiny-cnb
-
+```
 <p class="note"><strong>Note:</strong> Both build and run images need to be provided to update the stack.</p>
 
 The updated stack can be viewed with the following command:
 
-    kp stack status <stack-name>
+     `kp stack status <stack-name>`
 
 ### <a id='online-store-update'></a> Store Update
-	    	    
+
+The current list of buildpackages available for updates and their image references
+
+```
+paketo-buildpacks/go                gcr.io/paketo-buildpacks/go
+paketo-buildpacks/dotnet-core       gcr.io/paketo-buildpacks/dotnet-core
+paketo-buildpacks/php               gcr.io/paketo-buildpacks/php
+paketo-buildpacks/httpd             gcr.io/paketo-buildpacks/httpd
+paketo-buildpacks/nginx             gcr.io/paketo-buildpacks/nginx
+paketo-buildpacks/procfile          gcr.io/paketo-buildpacks/procfile
+```
+	  
 Update a store:
+	    
+     `kp store add <store-name> gcr.io/paketo-buildpacks/buildpackage`
+	    
+Here is an example to update the `dotnet-core` buildpackage
+	    
+     `kp store add default gcr.io/paketo-buildpacks/dotnet-core`
 
-    kp store add <store-name> gcr.io/paketo-buildpacks/language-family
+Additionally, multiple buildpackages can be added to Build Service by passing multiple image references
 
-Additionally, multiple buildpacks can be added to Build Service by passing multiple image references
-
-    kp store add <store-name> gcr.io/paketo-buildpacks/language-family1 gcr.io/paketo-buildpacks/language-family2 gcr.io/paketo-buildpacks/language-family3
+    `kp store add <store-name> gcr.io/paketo-buildpacks/buildpacakge-1 gcr.io/paketo-buildpacks/buildpackage-2 gcr.io/paketo-buildpacks/buildpackage-3`
 
 To list the buildpacks now available in the store:
 
-    kp store status <store-name>
+    `kp store status <store-name>`

--- a/updating-deps.html.md.erb
+++ b/updating-deps.html.md.erb
@@ -3,32 +3,20 @@ title: Updating Build Service Dependencies
 owner: Build Service Team
 ---
 
-Visit the [Build Service dependencies tile on PivNet](https://network.pivotal.io/products/tbs-dependencies). Build Service can be updated with those artifacts both directly against the PivNet registry or via the downloaded versions of those images.
-
-#### <a id='tanzu-net-registry-sign-in'></a> Accessing the Tanzu Net Registry
-
-The Tanzu Net registry (registry.pivotal.io) contains the stack and buildpack images needed to keep Tanzu Build Service up to date to keep applications secure. Once you login to the Tanzu Net registry, you can use the `kp` cli to update dependencies.
-
-You will need the `docker` cli to authenticate with the Tanzu Net registry.
-
-To login to the Tanzu Net registry, run:
-
-	docker login registry.pivotal.io
-
-When prompted for a username and password, use the same credentials you used to login to [Tanzu Net](https://network.pivotal.io).
+Visit the [The Paketo Buildpacks Github repo](https://github.com/paketo-buildpacks). Build Service can be updated with the artifacts provided in the repo via the GCR registry in which these dependencies live.
 
 ## <a id='online-update'></a> Online update of Dependencies
 
-If the `kp` CLI has access to pull images from the TanzuNet Registry. The stack images and buildpacks used by build service can be updated using the following commands.
+The Paketo repository contains references to images for buildpacks that are divided by language family (java, node, etc...) and stack images. Use the `kp` CLI to update these dependencies by referring to the desired images using the below commands. 
 
 ### <a id='online-stack-update'></a> Stacks Update
 
 Update the stacks:
 
-    kp stack update base --build-image registry.pivotal.io/tbs-dependencies/build-base@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-base@sha256:<image-sha>
-    kp stack update default --build-image registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha>
-    kp stack update full --build-image registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha>
-    kp stack update tiny --build-image registry.pivotal.io/tbs-dependencies/build-tiny@sha256:<image-sha> --run-image registry.pivotal.io/tbs-dependencies/run-tiny@sha256:<image-sha>
+    kp stack update base --build-image gcr.io/paketo-buildpacks/build:base-cnb --run-image gcr.io/paketo-buildpacks/run:base-cnb
+    kp stack update default --build-image gcr.io/paketo-buildpacks/build:full-cnb-cf --run-image index.docker.io/paketobuildpacks/build:full-cnb-cf
+    kp stack update default --build-image gcr.io/paketo-buildpacks/build:full-cnb-cf --run-image index.docker.io/paketobuildpacks/build:full-cnb-cf
+    kp stack update tiny --build-image gcr.io/paketo-buildpacks/build:tiny-cnb --run-image gcr.io/paketo-buildpacks/run:tiny-cnb
 
 <p class="note"><strong>Note:</strong> Both build and run images need to be provided to update the stack.</p>
 
@@ -37,45 +25,15 @@ The updated stack can be viewed with the following command:
     kp stack status <stack-name>
 
 ### <a id='online-store-update'></a> Store Update
-
+	    	    
 Update a store:
 
-    kp store add <store-name> registry.pivotal.io/tbs-dependencies/<buildpack-name>:<buildpack-tag>
+    kp store add <store-name> gcr.io/paketo-buildpacks/language-family
 
 Additionally, multiple buildpacks can be added to Build Service by passing multiple image references
 
-    kp store add <store-name> registry.pivotal.io/tbs-dependencies/<buildpack1>:<buildpack1-tag> registry.pivotal.io/tbs-dependencies/<buildpack2>:<buildpack2-tag> registry.pivotal.io/tbs-dependencies/<buildpack3>:<buildpack3-tag>
+    kp store add <store-name> gcr.io/paketo-buildpacks/language-family1 gcr.io/paketo-buildpacks/language-family2 gcr.io/paketo-buildpacks/language-family3
 
 To list the buildpacks now available in the store:
 
     kp store status <store-name>
-
-## <a id='offline-update'></a> Offline update of Dependencies
-
-If the `kp` CLI cannot access the images in the Pivnet Registry, the stack images and buildpacks used by build service can be updated by first downloading those images and saving them as `.tar` files. These file can be provided to the `kp` CLI to upload to build service.
-
-### <a id='offline-stack-update'></a> Stack Update
-
-Fetch the stack images into the docker daemon:
-
-    docker pull registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha>
-    docker pull registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha>
-
-Save those images to disk:
-
-    docker save registry.pivotal.io/tbs-dependencies/build-full@sha256:<image-sha> > build.tar
-    docker save registry.pivotal.io/tbs-dependencies/run-full@sha256:<image-sha> > run.tar
-
-Update the stack with the saved image:
-
-    kp stack update full --build-image build.tar --run-image run.tar
-
-<p class="note"><strong>Note:</strong> Both build and run images need to be provided to update the stack.</p>
-
-The updated stack can be viewed with the following command:
-
-    kp stack status
-
-### <a id='offline-store-update'></a> Store Update
-
-Offline store updates using the Tanzu Net registry is not currently supported but will be in upcoming releases.


### PR DESCRIPTION
Due to release 3 of the TBS deps page being caught in OSL purgatory.  The dependencies listed there are from the 0.1.0 phase of TBS and reference the `pb` CLI.  This has caused a great deal of confusion for one customer in particular (Accenture) when trying to to update dependencies.  Given that even if release 3 is granted its OSL file, the dependencies in release 3 would simply be the same ones that are already configured in the customer's cluster from installing 0.2.0.  

This PR is a rather inelegant solution intended to be a stopgap until GA.  It removes all reference to the TBS deps page and instead points to the public Paketo github page.  I'm definitely looking for feedback on this as there are many ways we could solve this problem.  One specific thing I'm wondering is if we point people to Paketo, what guidance should we provide around the Java buildpacks.  0.2.0 installs buildpacks with Tanzu IDs, and Paketo provides Java buildpacks with Paketo IDs.  Could this cause confusion in the store if we suggest customers consume new versions of Paketo Java buildpacks?