### PR TITLE
Some index updates

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -43,35 +43,45 @@ A `ClusterStack` defines a pair of build and run OS images. Critical security vu
 
 For more information see the [Managing ClusterStacks](managing-stacks.html) page.
 
-## <a id='upgrading-dependencies'></a> Updating Build Service Dependencies
-
-Build Service allows the user to update Buildpacks and ClusterStore images via the `kp` CLI. You can learn more about updating Build Service dependencies [here](updating-deps.html).
-
-## <a id='upgrading-dependencies'></a> Build Service Components
+## <a id='components'></a> Build Service Components
 
 Tanzu Build Service 1.0.0 ships with the following components:
 
 * [kpack 0.1.0](https://github.com/pivotal/kpack/releases/tag/v0.1.0)
 * [CNB lifecycle v0.9.0](https://github.com/buildpacks/lifecycle/releases/tag/v0.9.0)
-* [kp cli v0.1.0](https://github.com/pivotal/kpack-cli/releases/tag/v0.1.0)
+* [kp cli v0.1.0](https://network.pivotal.io/products/build-service#/releases/716705)
 
-[Tanzu Build Service Dependencies](https://network.pivotal.io/products/tbs-dependencies/) 3.0.0 ships with the following buildpacks:
+## <a id='dependencies'></a> Build Service Dependencies
 
-* Tanzu Java `tanzu-buildpacks/java`
-* Tanzu NodeJS `tanzu-buildpacks/nodejs`
+### <a id='buildpacks'></a> Buildpacks
+
+New versions for the following buildpacks can be found on their respective Tanzu Network pages:
+
+* [Tanzu Java](https://network.pivotal.io/products/tanzu-java-buildpack) `tanzu-buildpacks/java`
+* [Tanzu Golang](https://network.pivotal.io/products/tanzu-go-buildpack) `tanzu-buildpacks/go`
+* [Tanzu NodeJS](https://network.pivotal.io/products/tanzu-nodejs-buildpack) `tanzu-buildpacks/nodejs`
+
+Currently, the following buildpacks do not yet have their own pages on Tanzu Network and can be found on the [Tanzu Build Service Dependencies](https://network.pivotal.io/products/tbs-dependencies/) page:
+
 * Paketo .NET Core `paketo-buildpacks/dotnet-core`
-* Tanzu Golang `tanzu-buildpacks/go`
 * Tanzu PHP `tanzu-buildpacks/php`
 * Tanzu HTTPD `tanzu-buildpacks/httpd`
 * Tanzu NGINX `tanzu-buildpacks/nginx`
 * Paketo Procfile `paketo-buildpacks/procfile`
 
-[Tanzu Build Service Dependencies](https://network.pivotal.io/products/tbs-dependencies/) 3.0.0 ships with the following stacks:
+### <a id='stacks'></a> Stacks
+
+Updated Stacks can be found on the [Tanzu Build Service Dependencies](https://network.pivotal.io/products/tbs-dependencies/) page.
+
+The following stacks will be provided:
 
 * tiny `io.paketo.stacks.tiny`
 * base `io.buildpacks.stacks.bionic`
 * full `io.buildpacks.stacks.bionic`
 
+### <a id='upgrading-dependencies'></a> Updating Build Service Dependencies
+
+Build Service allows the user to update Buildpacks and Stacks via the `kp` CLI. You can learn more about updating Build Service dependencies [here](updating-deps.html).
 
 ## <a id='troubleshooting'></a> Troubleshooting
 


### PR DESCRIPTION
- Use Tanzu Net release for kp cli as it is not available anywhere else yet.
  This should be updated to the open-source repo when it exists
- Remove TBS dependencies version reference (3.0.0) because it should
  release with high cadence and we shouldn't keep updating the docs
- Some refactoring of components and dependency components