### PR TITLE
Do not hardcode tbs version in install docs

### DIFF
--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -38,7 +38,7 @@ Build Service utilizes `PersistentVolumeClaims` to cache build artifacts, which 
 
 For this example setup, we will make the following assumptions:
 
-* You are installing TBS 1.2.0
+* You are installing TBS 1.2.1 (This is the latest version at the time of writing. Go to the [Tanzu Build Service](https://network.pivotal.io/products/build-service/) page to find the most up-to-date version).
 * You are using a registry named `my.registry.io` with credentials
   * Username: `my-user`
   * Password: `my-password`
@@ -67,13 +67,13 @@ docker login registry.pivotal.io
 3. Relocate the images with the [Carvel](https://carvel.dev/) tool `imgpkg` by running:
 
 ```
-imgpkg copy -b "registry.pivotal.io/build-service/bundle:1.2.0" --to-repo my.registry.io/tbs --registry-ca-cert-path /tmp/ca.crt
+imgpkg copy -b "registry.pivotal.io/build-service/bundle:1.2.1" --to-repo my.registry.io/tbs --registry-ca-cert-path /tmp/ca.crt
 ```
 
 4. Pull the Tanzu Build Service bundle locally using `imgpkg`:
 
 ```
-imgpkg pull -b "my.registry.io/tbs:1.2.0" -o /tmp/bundle
+imgpkg pull -b "my.registry.io/tbs:1.2.1" -o /tmp/bundle
 ```
 
 ### <a id='install'></a> Install Tanzu Build Service

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -97,10 +97,10 @@ image name that imgpkg will use for relocation. For example, <code>my-dockerhub-
 
 For example:
 
-* Dockerhub `imgpkg copy -b "registry.pivotal.io/build-service/bundle:1.2.0" --to-repo my-dockerhub-account/build-service`
-* GCR `imgpkg copy -b "registry.pivotal.io/build-service/bundle:1.2.0" --to-repo gcr.io/my-project/build-service`
-* Artifactory `imgpkg copy -b "registry.pivotal.io/build-service/bundle:1.2.0" --to-repo artifactory.com/my-project/build-service`
-* Harbor `imgpkg copy -b "registry.pivotal.io/build-service/bundle:1.2.0" --to-repo harbor.io/my-project/build-service`
+* Dockerhub `imgpkg copy -b "registry.pivotal.io/build-service/bundle:<TBS-VERSION>" --to-repo my-dockerhub-account/build-service`
+* GCR `imgpkg copy -b "registry.pivotal.io/build-service/bundle:<TBS-VERSION>" --to-repo gcr.io/my-project/build-service`
+* Artifactory `imgpkg copy -b "registry.pivotal.io/build-service/bundle:<TBS-VERSION>" --to-repo artifactory.com/my-project/build-service`
+* Harbor `imgpkg copy -b "registry.pivotal.io/build-service/bundle:<TBS-VERSION>" --to-repo harbor.io/my-project/build-service`
 
 <p class="note">
 <strong>Note:</strong> During relocation, imgpkg will report the following:


### PR DESCRIPTION
- Only hardcode a version number in the getting started guide

FWIW we currently have this messaging currently so I don't think we need too much more:

(In Prerequisites)
<img width="672" alt="Screen Shot 2021-07-20 at 2 58 27 PM" src="https://user-images.githubusercontent.com/7309317/126380505-33ac2aa3-d445-416b-a64c-530365cc8a44.png">

(In relocation step)
<img width="709" alt="Screen Shot 2021-07-20 at 2 58 39 PM" src="https://user-images.githubusercontent.com/7309317/126380502-82b8304d-670c-45f3-a058-4c2efe3f3ced.png">
