### PR TITLE
Use single quotes in install examples

### DIFF
--- a/faq.html.md.erb
+++ b/faq.html.md.erb
@@ -121,9 +121,9 @@ If you have trouble configuring the registry credentials for gcr when following 
 	registry_password="$(cat /path/to/gcp/service/account/key.json)"
 	ytt -f /tmp/bundle/values.yaml \
 		-f /tmp/bundle/config/ \
-		-v docker_repository="<IMAGE-REPOSITORY>" \
+		-v docker_repository='<IMAGE-REPOSITORY>' \
 		-v docker_username="$registry_name" \
-		-v docker_password="$registry_password>" \
+		-v docker_password="$registry_password" \
 		| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 		| kapp deploy -a tanzu-build-service -f- -y
 
@@ -144,12 +144,12 @@ This is a known limitation and can be circumvented by using <code>no_proxy</code
 ```
 ytt -f /tmp/bundle/values.yaml \
 	-f /tmp/bundle/config/ \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
-	-v http_proxy="<HTTP-PROXY-URL>" \
-	-v https_proxy="<HTTPS-PROXY-URL>" \
-	-v no_proxy="<KUBERNETES-API-SERVER-URL>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
+	-v http_proxy='<HTTP-PROXY-URL>' \
+	-v https_proxy='<HTTPS-PROXY-URL>' \
+	-v no_proxy='<KUBERNETES-API-SERVER-URL>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```

--- a/getting-started.html.md.erb
+++ b/getting-started.html.md.erb
@@ -84,9 +84,9 @@ Use the [Carvel](https://carvel.dev/) tools `kapp`, `ytt`, and `kbld` to install
 ytt -f /tmp/bundle/values.yaml \
     -f /tmp/bundle/config/ \
     -f /tmp/ca.crt \
-	-v docker_repository="my.registry.io/tbs" \
-	-v docker_username="my-user" \
-	-v docker_password="my-password" \
+	-v docker_repository='my.registry.io/tbs' \
+	-v docker_username='my-user' \
+	-v docker_password='my-password' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -134,11 +134,11 @@ Tanzu Build Service 1.2 ships with a dependency updater that can update ClusterS
 ```
 ytt -f /tmp/bundle/values.yaml \
     -f /tmp/bundle/config/ \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
-	-v tanzunet_username="<TANZUNET-USERNAME>" \
-	-v tanzunet_password="<TANZUNET-PASSWORD>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
+	-v tanzunet_username='<TANZUNET-USERNAME>' \
+	-v tanzunet_password='<TANZUNET-PASSWORD>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```
@@ -149,9 +149,9 @@ Alternatively, if you prefer to manage dependencies yourself, simply leave the T
 ```
 ytt -f /tmp/bundle/values.yaml \
     -f /tmp/bundle/config/ \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```
@@ -183,9 +183,9 @@ installation command with the CA certificate file passed in with a `-f` flag:
 ytt -f /tmp/bundle/values.yaml \
 	-f /tmp/bundle/config/ \
 	-f <PATH-TO-CA> \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```
@@ -368,9 +368,9 @@ Where `TBS-VERSION` and `IMAGE-REPOSITORY` are the same values used during reloc
 ytt -f /tmp/bundle/values.yaml \
     -f /tmp/bundle/config/ \
     -f <PATH-TO-CA> \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```
@@ -493,11 +493,11 @@ Tanzu Build Service 1.2 ships with a dependency updater that can update ClusterS
 ```
 ytt -f /tmp/bundle/values.yaml \
     -f /tmp/bundle/config/ \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
-	-v tanzunet_username="<TANZUNET-USERNAME>" \
-	-v tanzunet_password="<TANZUNET-PASSWORD>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
+	-v tanzunet_username='<TANZUNET-USERNAME>' \
+	-v tanzunet_password='<TANZUNET-PASSWORD>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```
@@ -509,9 +509,9 @@ Alternatively, if you prefer to manage dependencies yourself, simply leave the c
 ```
 ytt -f /tmp/bundle/values.yaml \
     -f /tmp/bundle/config/ \
-	-v docker_repository="<IMAGE-REPOSITORY>" \
-	-v docker_username="<REGISTRY-USERNAME>" \
-	-v docker_password="<REGISTRY-PASSWORD>" \
+	-v docker_repository='<IMAGE-REPOSITORY>' \
+	-v docker_username='<REGISTRY-USERNAME>' \
+	-v docker_password='<REGISTRY-PASSWORD>' \
 	| kbld -f /tmp/bundle/.imgpkg/images.yml -f- \
 	| kapp deploy -a tanzu-build-service -f- -y
 ```


### PR DESCRIPTION
- This ensures no interpolation of critical values