### PR TITLE
Fix typo in anchor.

### DIFF
--- a/updating-deps.html.md.erb
+++ b/updating-deps.html.md.erb
@@ -190,7 +190,7 @@ kp clusterstore add <store-name> \
   -b registry.pivotal.io/buildpackage-3
 ```
 
-## <a id='online-update'></a> Offline Update of Dependencies
+## <a id='offline-update'></a> Offline Update of Dependencies
 
 The stack images and buildpacks used by build service can be updated by first downloading those images and saving them as a .tar file. This file can be provided to the `kp` CLI to import to Tanzu Build Service.
 


### PR DESCRIPTION
Update the anchor for "Offline Update of Dependencies" from `online-update` to `offline-update`.
The `online-update` anchor is already used earlier in the page, which made the sidebar link to "Offline Update..." go to the wrong place.

Signed-off-by: Mikey Boldt <mboldt@vmware.com>