### PR TITLE
Document that CustomStacks do not support being pushed to private registries that require a ca cert

### DIFF
--- a/managing-custom-stacks.html.md.erb
+++ b/managing-custom-stacks.html.md.erb
@@ -5,8 +5,8 @@ owner: Build Service Team
 
 A CustomStack is a resource that allows users to create a customized [ClusterStack](managing-stacks.html) from Ubuntu 18.04 (Bionic Beaver) and UBI7/UBI8 non-minimal based OCI images.
 
-<p class='note'><strong>Note:</strong> Customstacks created with UBI7/UBI8 images do not currently support adding packages, mixins, or caCerts.  Currently, only the Java Tanzu Buildpacks support CustomStacks that use UBI images. </p>
-<p class='note'><strong>Note:</strong> Private registries which require a custom CA certificate are not currently supported as a publishing destination for Customstack images.</p>
+<p class='note'><strong>Note:</strong> CustomStacks created with UBI7/UBI8 images do not currently support adding packages, mixins, or caCerts.  Currently, only the Java Tanzu Buildpacks support CustomStacks that use UBI images. </p>
+<p class='note'><strong>Note:</strong> Private registries which require a custom CA certificate are not currently supported as publishing destinations for CustomStack images.</p>
 
 CustomStacks can be used to:
 

--- a/managing-custom-stacks.html.md.erb
+++ b/managing-custom-stacks.html.md.erb
@@ -5,7 +5,8 @@ owner: Build Service Team
 
 A CustomStack is a resource that allows users to create a customized [ClusterStack](managing-stacks.html) from Ubuntu 18.04 (Bionic Beaver) and UBI7/UBI8 non-minimal based OCI images.
 
-<p class='note'><strong>Note:</strong> Customstacks created with UBI7/UBI8 images do not currently support adding packages, mixins, or caCerts.  Currently, only the Java Tanzu Buildpacks support CustomStacks that use UBI images </p>
+<p class='note'><strong>Note:</strong> Customstacks created with UBI7/UBI8 images do not currently support adding packages, mixins, or caCerts.  Currently, only the Java Tanzu Buildpacks support CustomStacks that use UBI images. </p>
+<p class='note'><strong>Note:</strong> Private registries which require a custom CA certificate are not currently supported as a publishing destination for Customstack images.</p>
 
 CustomStacks can be used to:
 


### PR DESCRIPTION
This is a fix for https://github.com/pivotal/build-service/issues/712.