### PR TITLE
descriptors: Add ruby and web servers to lite+full

### DIFF
--- a/descriptors.html.md.erb
+++ b/descriptors.html.md.erb
@@ -65,5 +65,7 @@ Both `lite` and `full` descriptors are suitable for production environments.
 | Supports Python workloads | Yes | Yes |
 | Supports .NET Core workloads | Yes | Yes |
 | Supports PHP workloads | No | Yes |
+| Supports Ruby workloads | Yes | Yes |
+| Supports Web Servers workloads | Yes | Yes |
 | Supports static workloads | Yes | Yes |
 | Supports binary workloads | Yes | Yes |


### PR DESCRIPTION
Ruby and webservers are now part of https://github.com/pivotal/build-service/tree/main/descriptors

cc @johnnyr0x 